### PR TITLE
Add documentation of handlers

### DIFF
--- a/src/libosmium/input-and-output.md
+++ b/src/libosmium/input-and-output.md
@@ -183,7 +183,7 @@ reader.close();
 ~~~
 
 In most cases you do not want to work with the buffers, but with the OSM
-entities within them. See the [Iterators] chapter and the [Visitors and Handlers]
+entities within them. See the [Iterators] chapter and the [Handlers]
 chapter for more convenient methods of working with open files.
 
 

--- a/src/libosmium/visitors-and-handlers.md
+++ b/src/libosmium/visitors-and-handlers.md
@@ -1,3 +1,95 @@
 
-# Visitors and Handlers
+# Handlers
+
+If you process OSM data with libosmium to do something (e.g. convert to a different format,
+import into a database, build a routing graph), you will usually create one or more *handlers*.
+
+Handlers are created by deriving a class from `osmium::handler::Handler` which defines
+methods for all OSM object types, i.e. a method `node(const osmium::Node&)` for nodes, a
+method `way(const osmium::Way&)` for ways etc.
+You have to implement the methods for the object types you want to process. libosmium
+will read the data, fed it object by object into the handler and you can do there whatever
+you want. Your handler may have temporary storage, e.g. if you want to sum up the length of
+all roads in an OSM file.
+
+~~~{.cpp}
+#include <iostream>
+#include <osmium/handler.hpp>
+#include <osmium/osm/node.hpp>
+#include <osmium/osm/way.hpp>
+#include <osmium/io/any_input.hpp>
+#include <osmium/io/reader.hpp>
+#include <osmium/visitor.hpp>
+
+class MyHandler : public osmium::handler::Handler {
+public:
+    void way(const osmium::Way& way) {
+        std::cout << "way " << way.id() << '\n';
+        for (const osmium::Tag& t : way.tags()) {
+            std::cout << t.key() << "=" << t.value() << '\n';
+        }
+    }
+
+    void node(const osmium::Node& node) {
+        std::cout << "node " << node.id() << '\n';
+    }
+};
+
+int main(int, char**) {
+    osmium::io::Reader reader ("input.osm.pbf", osmium::osm_entity_bits::node | osmium::osm_entity_bits::way);
+    MyHandler handler;
+    osmium::apply(reader, handler);
+    reader.close();
+}
+~~~
+
+The example above reads an OSM file and writes some informations about nodes and ways to `STDOUT`.
+
+You can define multiple handlers, osmium will fed the object into the handlers one after another.
+Just add the additional handlers to `osmium::apply()` which accepts a reader and one or multiple
+handlers.
+
+Multiple handlers are necessary if you want to access the locations of the nodes referenced by a
+way because the way itself only contains references to the nodes. A special handler has to offer
+methods to look up the location by the ID of a node. The best index type for this
+`NodeLocationsForWays` handler depends on the size of the file, the available memory and the
+operating system. See [Osmium Concept Manual](../osmium-concepts-manual/#indexes) for details.
+
+~~~{.cpp}
+#include <iostream>
+#include <osmium/handler.hpp>
+#include <osmium/osm/node.hpp>
+#include <osmium/osm/way.hpp>
+#include <osmium/io/any_input.hpp>
+#include <osmium/io/reader.hpp>
+#include <osmium/visitor.hpp>
+#include <osmium/index/map/sparse_mem_array.hpp>
+#include <osmium/handler/node_locations_for_ways.hpp>
+
+
+class MyHandler : public osmium::handler::Handler {
+public:
+    void way(const osmium::Way& way) {
+        std::cout << "way " << way.id() << '\n';
+        for (auto n : way.nodes()) {
+            std::cout << n.ref() << ": " << n.lon() << ", " << n.lat() << '\n';
+        }
+    }
+};
+
+int main(int, char**) {
+    typedef osmium::index::map::SparseMemArray<osmium::unsigned_object_id_type, osmium::Location> index_type;
+    typedef osmium::handler::NodeLocationsForWays<index_type> location_handler_type;
+    osmium::io::Reader reader ("input.osm.pbf", osmium::osm_entity_bits::node | osmium::osm_entity_bits::way);
+    index_type index;
+    location_handler_type location_handler(index);
+    MyHandler handler;
+    osmium::apply(reader, location_handler, handler);
+    reader.close();
+}
+~~~
+
+You can find lots of examples how to use a handler at the
+[examples](https://github.com/osmcode/libosmium/tree/master/examples) of libosmium and
+[osmium-contrib](https://github.com/osmcode/osmium-contrib) repository.
 


### PR DESCRIPTION
The visitor interface was dropped more than two years ago in commits
445cafa3109477023d36bc44cda3e83dea06bb09 and
b4394905b37d963c4908caf0dc8b3c4ec0785544 of libosmium on June 18, 2014.
visitor.hpp as a file name is the only leftover of that change.
Therefore, I decided to remove "Visitor" from the title of this section.

I have tested both code snippets (compiled and run).

I will document how to work with areas (area assembler, multipolygon collector) and relations (writing your own collector by deriving a class from Collector) in a further pull request next week.